### PR TITLE
Publish features

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,4 +57,4 @@ export interface PublishArgs {
  * This implments the `publish` step for `sementic-release` for a Cargo-based
  * Rust workspace.
  */
-export function publish(noDirty: boolean): void;
+export function publish(opts?: PublishArgs | undefined | null): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,13 @@ export function verifyConditions(): void;
  * workspace.
  */
 export function prepare(nextReleaseVersion: string): void;
+/** Arguments to be passed to the `publish` function. */
+export interface PublishArgs {
+  /** Whether the `--no-dirty` flag should be passed to `cargo publish`. */
+  noDirty?: boolean
+  /** A map of packages and features to pass to `cargo publish`. */
+  features?: Record<string, Array<string>>
+};
 /**
  * Publish the publishable crates from the workspace.
  *

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function prepare(pluginConfig, context) {
 }
 
 function publish(pluginConfig, context) {
-  semanticReleaseCargo.publish(false);
+  semanticReleaseCargo.publish(pluginConfig);
 }
 
 module.exports = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![deny(warnings, missing_docs)]
 
 use std::{
+    collections::HashMap,
     env, fmt, fs,
     io::{BufRead, Cursor, Write},
     path::{Path, PathBuf},
@@ -310,6 +311,17 @@ fn internal_prepare(
     }
 
     Ok(())
+}
+
+#[cfg_attr(feature = "napi-rs", napi(object))]
+#[derive(Debug, Default)]
+/// Arguments to be passed to the `publish` function.
+pub struct PublishArgs {
+    /// Whether the `--no-dirty` flag should be passed to `cargo publish`.
+    pub no_dirty: Option<bool>,
+
+    /// A map of packages and features to pass to `cargo publish`.
+    pub features: Option<HashMap<String, Vec<String>>>,
 }
 
 /// Publish the publishable crates from the workspace.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,6 +530,10 @@ fn publish_package(pkg: &PackageMetadata, opts: &PublishArgs) -> Result<()> {
     if !opts.no_dirty.unwrap_or_default() {
         command.arg("--allow-dirty");
     }
+    if let Some(features) = opts.features.as_ref().and_then(|f| f.get(pkg.name())) {
+        command.arg("--features");
+        command.args(features);
+    }
 
     trace!("running: {:?}", command);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use human_panic::setup_panic;
 use log::Level;
 use loggerv::{Logger, Output};
 
-use semantic_release_cargo::{list_packages, prepare, publish, verify_conditions};
+use semantic_release_cargo::{list_packages, prepare, publish, verify_conditions, PublishArgs};
 
 /// Run sementic-release steps in the context of a cargo based Rust project.
 #[derive(Parser)]
@@ -151,7 +151,20 @@ impl Subcommand {
                 opt.common.manifest_path(),
                 opt.next_version.clone(),
             )?),
-            Publish(opt) => Ok(publish(w, opt.common.manifest_path(), opt.no_dirty)?),
+            Publish(opt) => Ok(publish(
+                w,
+                opt.common.manifest_path(),
+                &PublishArgs {
+                    no_dirty: Some(opt.no_dirty),
+                    features: Some(opt.features.iter().cloned().fold(
+                        Default::default(),
+                        |mut a, (k, v)| {
+                            a.entry(k).or_default().push(v);
+                            a
+                        },
+                    )),
+                },
+            )?),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,30 @@ struct PublishOpt {
     /// Disallow publishing with uncommited files in the workspace.
     #[clap(long)]
     no_dirty: bool,
+
+    /// The features to use when publishing the workspace.
+    /// This is a comma separated list of key-value pairs where the key is the
+    /// name of the package and the value a feature for that package.
+    /// For example, `--features foo=bar,baz=qux` will set the `bar` feature for
+    /// the `foo` package and the `qux` feature for the `baz` package.
+    #[clap(long, value_parser = parse_key_val::<String, String>, value_delimiter = ',')]
+    features: Vec<(String, String)>,
+}
+
+/// Parse a single key-value pair
+fn parse_key_val<T, U>(
+    s: &str,
+) -> Result<(T, U), Box<dyn std::error::Error + Send + Sync + 'static>>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: std::error::Error + Send + Sync + 'static,
+{
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{}`", s))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 
 impl Subcommand {


### PR DESCRIPTION
This PR allows you to specify a map with features that should be applied when building packages for publishing. It takes the format:

```json
[
  "@semantic-release-cargo/semantic-release-cargo",
  {
    "features": {
      "my_package": ["feat-1", "feat-2"],
      "my_other_package": ["feat-3"]
    }
  }
]
```

This can also be used over the command line:

```
cargo run -- publish --features my_package=feat-1,my_package=feat-2,my_other_package=feat-3
```

Closes #48 