### PR TITLE
docs: document registry option in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,20 @@ your Rust crate to crates.io.
 
 If publishing to [crates.io], you must set the `CARGO_REGISTRY_TOKEN` environment variable.
 
-If publishing to an [alternate registry](https://doc.rust-lang.org/cargo/reference/registries.html#using-an-alternate-registry), you must set the `CARGO_REGISTRIES_<YOUR REGISTRY>_TOKEN` environment variable.
+If publishing to an [alternate registry](https://doc.rust-lang.org/cargo/reference/registries.html#using-an-alternate-registry), you must set the `CARGO_REGISTRIES_<YOUR REGISTRY>_TOKEN` environment variable and add the registry to the `releaserc` configuration to be passed to the `--registry` flag.
 
+```json
+{
+  "plugins": [
+    [
+      "@semantic-release-cargo/semantic-release-cargo",
+      {
+        "registry": "<YOUR REGISTRY>"
+      }
+    ]
+  ]
+}
+```
 
 This workflow is supported on the following systems:
 


### PR DESCRIPTION
Just setting the `CARGO_REGISTRIES_<YOUR REGISTRY>_TOKEN` by itself does not configure the plugin to publish to the alternate registry. In fact, the publish will silently fail _without an error_ if the `Cargo.toml` specifies an alternate registry.

A required step to publish to alternate registries is to configure the `registry` in the `.releaserc.json` configuration file.
```json
{
  "plugins": [
    [
      "@semantic-release-cargo/semantic-release-cargo",
      {
        "registry": "<YOUR REGISTRY>"
      }
    ]
  ]
}
```

This PR updates the README with these new instructions.

**TODO:** There is an additional issue where the `verifyConditions` step seems to always assume that the target registry is `crates-io`, causing that step to fail if `CARGO_REGISTRY_TOKEN` is not set.