### PR TITLE
ci: use ubuntu-24.04 to work around glibc issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,25 +73,25 @@ jobs:
           - os: macOS-latest
             target: aarch64-apple-darwin
             cross: true
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             cross: true
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-musl
             cross: true
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: i686-unknown-linux-gnu
             cross: true
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: i686-unknown-linux-musl
             cross: true
           - os: macOS-latest
             target: x86_64-apple-darwin
             cross: false
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             cross: false
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             cross: false
 
@@ -251,7 +251,7 @@ jobs:
           retention-days: 1
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Release
     if: needs.get-next-version.outputs.new-release-published == 'true'
     needs:


### PR DESCRIPTION
This commit temporarily changes the build host to Ubuntu 24.04 to alleviate the issue of a lower glibc version. Can be changed back to `ubuntu-latest` once GitHub switches over around New Year.